### PR TITLE
fix(protocol): register zen links on Linux

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -80,10 +80,10 @@ public partial class App : Application
                 var configService = Services.GetService<IAppConfigService>();
                 if (configService is AppConfigService acs)
                 {
-                    var config = await acs.TryLoadAsync();
+                    var config = await acs.TryLoadAsync() ?? new AppConfig();
                     // Always re-register if the current scheme isn't registered
                     // (handles scheme rename from cbeta:// to zen://)
-                    if (config != null && (!config.HasRegisteredProtocolHandler || !ProtocolRegistrationService.IsRegistered()))
+                    if (!config.HasRegisteredProtocolHandler || !ProtocolRegistrationService.IsRegistered())
                     {
                         ProtocolRegistrationService.Register();
                         config.HasRegisteredProtocolHandler = true;

--- a/Services/ProtocolRegistrationService.cs
+++ b/Services/ProtocolRegistrationService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace CbetaTranslator.App.Services;
@@ -153,13 +154,25 @@ public static class ProtocolRegistrationService
 
     private static bool IsRegisteredLinux()
     {
-        return File.Exists(GetDesktopFilePath());
+        try
+        {
+            var desktopPath = GetDesktopFilePath();
+            if (!File.Exists(desktopPath))
+                return false;
+
+            var defaultHandler = RunAndCapture("xdg-mime", "query default x-scheme-handler/zen");
+            return string.Equals(defaultHandler, Path.GetFileName(desktopPath), StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static void RegisterLinux()
     {
-        var exePath = GetExePath();
-        if (string.IsNullOrEmpty(exePath))
+        var execLine = GetLinuxExecLine();
+        if (string.IsNullOrEmpty(execLine))
             return;
 
         try
@@ -172,22 +185,16 @@ public static class ProtocolRegistrationService
                 "[Desktop Entry]\n" +
                 "Type=Application\n" +
                 "Name=CBETA Translator\n" +
-                "Exec=" + exePath + " %u\n" +
+                "NoDisplay=true\n" +
+                "Exec=" + execLine + " %u\n" +
                 "StartupNotify=false\n" +
                 "Terminal=false\n" +
                 "MimeType=x-scheme-handler/zen;\n";
 
             File.WriteAllText(desktopPath, content);
 
-            // Register with xdg-mime
-            var psi = new ProcessStartInfo("xdg-mime", "default cbeta-translator.desktop x-scheme-handler/zen")
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-            };
-            using var proc = Process.Start(psi);
-            proc?.WaitForExit(5000);
+            RunAndCapture("xdg-mime", "default cbeta-translator.desktop x-scheme-handler/zen");
+            TryRun("update-desktop-database", QuoteDesktopArgument(appsDir));
         }
         catch (Exception ex)
         {
@@ -202,11 +209,75 @@ public static class ProtocolRegistrationService
             var desktopPath = GetDesktopFilePath();
             if (File.Exists(desktopPath))
                 File.Delete(desktopPath);
+
+            TryRun("update-desktop-database", QuoteDesktopArgument(Path.GetDirectoryName(desktopPath)!));
         }
         catch (Exception ex)
         {
             Debug.WriteLine("Failed to unregister zen:// protocol on Linux: " + ex.Message);
         }
+    }
+
+    private static string? GetLinuxExecLine()
+    {
+        var exePath = GetExePath();
+        if (!string.IsNullOrWhiteSpace(exePath) &&
+            !Path.GetFileName(exePath).Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+        {
+            return QuoteDesktopArgument(exePath);
+        }
+
+        var baseDir = AppContext.BaseDirectory;
+        var appHostCandidates = new[]
+        {
+            Path.Combine(baseDir, "CbetaTranslator.App"),
+            Path.Combine(baseDir, "publish", "linux-x64", "CbetaTranslator.App"),
+            Path.Combine(baseDir, "publish", "linux-arm64", "CbetaTranslator.App"),
+        };
+
+        var appHost = appHostCandidates.FirstOrDefault(File.Exists);
+        if (!string.IsNullOrWhiteSpace(appHost))
+            return QuoteDesktopArgument(appHost);
+
+        var dllPath = Path.Combine(baseDir, "CbetaTranslator.App.dll");
+        if (File.Exists(dllPath))
+            return QuoteDesktopArgument("dotnet") + " " + QuoteDesktopArgument(dllPath);
+
+        return null;
+    }
+
+    private static string RunAndCapture(string fileName, string arguments)
+    {
+        var psi = new ProcessStartInfo(fileName, arguments)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        using var proc = Process.Start(psi);
+        if (proc == null)
+            return "";
+
+        var stdout = proc.StandardOutput.ReadToEnd();
+        _ = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(5000);
+        return stdout.Trim();
+    }
+
+    private static void TryRun(string fileName, string arguments)
+    {
+        try
+        {
+            _ = RunAndCapture(fileName, arguments);
+        }
+        catch
+        {
+        }
+    }
+
+    private static string QuoteDesktopArgument(string value)
+    {
+        return "\"" + value.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
     }
 
     // ===== macOS =====


### PR DESCRIPTION
Problem:
First launch on Linux could skip zen:// registration entirely when config.json did not exist yet. The generated desktop handler could also point at an invalid command depending on how the app was run.

Changes:
- Create a default AppConfig during first-run auto-registration
- Register when the handler flag is unset or zen is not the default
- Resolve a runnable Linux Exec target for apphost or dotnet+dll
- Verify Linux registration via xdg-mime instead of file presence
- Refresh desktop metadata after register and unregister

Rationale:
Linux needs an actual x-scheme-handler registration, not just a desktop file on disk. First-run registration must also work in a cold profile with no existing config state.

Limitations:
This does not add an end-to-end browser integration test. Linux behavior still depends on xdg-mime and desktop tooling being available in the user environment.

Assumptions:
The zen:// scheme is the intended deep-link entry point. Linux users may launch either a published apphost or a dotnet-based development build.

Alternatives:
Keeping the old file-exists check was rejected because it reports false positives and misses broken handler associations. Relying only on published apphosts was rejected to preserve support for local development launches.